### PR TITLE
Support multiple Firefox profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.4.1
+------------------
+* Support multiple Firefox profiles
+
 1.3.6
 ------------------
 * README update - 'master' -> 'main'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * alphabetical sorting of containers
 * manual sorting mode
 * safely updates containers.json after manual changes
+* supports multiple Firefox profiles
 * preserves Firefox private container objects
 * creates backups of Firefox Container config prior to making changes
     * deletes backups older than 7 days

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ff-containers-sort",
-    version="1.3.6",
+    version="1.4.1",
     author="Naaman Campbell",
     author_email="naaman@clancampbell.id.au",
     description="Sorts and re-numbers Firefox Containers config objects in Firefox containers.json",


### PR DESCRIPTION
- re-organised code to support multiple executions
- prompt user when multiple profiles are detected
- fix: catch KeyError for unsupported platforms